### PR TITLE
Add Pauli gates to player starting inventory

### DIFF
--- a/the_game/models/player.py
+++ b/the_game/models/player.py
@@ -12,7 +12,9 @@ class Player:
     def __init__(self, slot):
         self.name: str = ""
         self.position: int = 0                      # Space ID
-        self.gates: dict = {'H':0,'X':0,'Y':0,'Z':0}  # gate counts
+        # Players start with a basic set of Pauli gates so they can
+        # immediately interact with the quantum board mechanics.
+        self.gates: dict = {'H':0, 'X':1, 'Y':1, 'Z':1}  # starting gate counts
         self.slot = slot
         self.name = ""
         self.order = slot + 1


### PR DESCRIPTION
## Summary
- players should begin with a small gate inventory
- update `Player` so each new player starts with one X, Y and Z gate

## Testing
- `python -m py_compile the_game/models/player.py`

------
https://chatgpt.com/codex/tasks/task_e_6854ba30e0bc8326a9f3e0eca89a5a51