### PR TITLE
Fix missing node value handling in game scene

### DIFF
--- a/the_game/scenes/game.py
+++ b/the_game/scenes/game.py
@@ -141,7 +141,7 @@ class GameScene(Scene):
             pygame.draw.circle(s, BLACK, (x,y), 30, 3)
 
             if data["type"] in (1,2):
-                label = str(data["value"])
+                label = str(data.get("value", ""))
             elif data["type"] == 3:
                 label = "⊕"
             else:  # type 4


### PR DESCRIPTION
## Summary
- avoid KeyError when a map node lacks a `value` attribute

## Testing
- `python -` snippet to instantiate `GameScene` on a dummy graph

------
https://chatgpt.com/codex/tasks/task_e_6854c61dbc2c8326a88d638b380ac7e5