### PR TITLE
Show numbers for unnamed YAML nodes

### DIFF
--- a/the_game/scenes/game.py
+++ b/the_game/scenes/game.py
@@ -141,7 +141,11 @@ class GameScene(Scene):
             pygame.draw.circle(s, BLACK, (x,y), 30, 3)
 
             if data["type"] in (1,2):
-                label = str(data.get("value", ""))
+                if "value" in data and data["value"] is not None:
+                    label = str(data["value"])
+                else:
+                    digits = "".join(ch for ch in n if ch.isdigit())
+                    label = digits
             elif data["type"] == 3:
                 label = "⊕"
             else:  # type 4


### PR DESCRIPTION
## Summary
- show node numbers by using digits from the node name when `value` is missing

## Testing
- `pytest -q`
- `python -m compileall -q the_game`


------
https://chatgpt.com/codex/tasks/task_e_6854ca090898832683f48f2c97d3d831