### PR TITLE
Add standalone quantum minigames

### DIFF
--- a/the_game/scenes/quantum_coin.py
+++ b/the_game/scenes/quantum_coin.py
@@ -1,0 +1,63 @@
+import pygame, sys
+from qiskit import QuantumCircuit
+from qiskit_aer import AerSimulator
+
+from settings import WIDTH, HEIGHT, WHITE, BLACK
+from core.scene import Scene, SceneManager
+from ui.widgets import Button
+
+class QuantumCoinScene(Scene):
+    """Simple coin flip using Qiskit AerSimulator."""
+    def __init__(self, manager):
+        super().__init__(manager)
+        self.font = pygame.font.SysFont(None, 48)
+        self.result = None
+        self.button = Button("Flip", (WIDTH//2, HEIGHT//2))
+
+    def _flip_coin(self):
+        qc = QuantumCircuit(1, 1)
+        qc.h(0)
+        qc.measure(0, 0)
+        sim = AerSimulator()
+        counts = sim.run(qc).result().get_counts()
+        # get most probable bit (since only one shot)
+        self.result = max(counts, key=counts.get)
+
+    def handle_event(self, e):
+        if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
+            pygame.quit(); sys.exit()
+        if self.button.handle_event(e):
+            self._flip_coin()
+        if e.type == pygame.QUIT:
+            pygame.quit(); sys.exit()
+
+    def update(self, dt):
+        pass
+
+    def draw(self, s):
+        s.fill(WHITE)
+        txt = self.font.render("Quantum Coin Toss", True, BLACK)
+        s.blit(txt, txt.get_rect(center=(WIDTH//2, 80)))
+        self.button.draw(s)
+        if self.result is not None:
+            res_txt = self.font.render(f"Result: {self.result}", True, BLACK)
+            s.blit(res_txt, res_txt.get_rect(center=(WIDTH//2, HEIGHT//2 + 80)))
+
+if __name__ == "__main__":
+    pygame.init()
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    clock = pygame.time.Clock()
+    from ui.widgets import init_fonts
+    font_l = pygame.font.SysFont(None, 72)
+    font_m = pygame.font.SysFont(None, 32)
+    font_s = pygame.font.SysFont(None, 24)
+    init_fonts(font_l, font_m, font_s)
+    manager = SceneManager(QuantumCoinScene(None))
+    manager.scene.manager = manager
+    while True:
+        dt = clock.tick(60) / 1000
+        for event in pygame.event.get():
+            manager.handle_event(event)
+        manager.update(dt)
+        manager.draw(screen)
+        pygame.display.flip()

--- a/the_game/scenes/statevector_demo.py
+++ b/the_game/scenes/statevector_demo.py
@@ -1,0 +1,79 @@
+import pygame, sys
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Statevector
+from qiskit.visualization import plot_bloch_vector
+
+import matplotlib.pyplot as plt
+
+from settings import WIDTH, HEIGHT, WHITE, BLACK
+from core.scene import Scene, SceneManager
+
+class StatevectorDemo(Scene):
+    """Simple interactive demo manipulating a single-qubit state."""
+    def __init__(self, manager):
+        super().__init__(manager)
+        self.font = pygame.font.SysFont(None, 36)
+        self.state = Statevector([1, 0])
+        self.image = None
+        self._update_image()
+        self.instructions = self.font.render(
+            "Press H/X/Y/Z to apply gate, ESC to exit", True, BLACK)
+
+    def _update_image(self):
+        px = float(self.state.expectation_value('X').real)
+        py = float(self.state.expectation_value('Y').real)
+        pz = float(self.state.expectation_value('Z').real)
+        fig = plot_bloch_vector([px, py, pz])
+        fig.savefig("/tmp/state.png")
+        plt.close(fig)
+        self.image = pygame.image.load("/tmp/state.png").convert_alpha()
+
+    def _apply(self, gate):
+        qc = QuantumCircuit(1)
+        getattr(qc, gate.lower())(0)
+        self.state = self.state.evolve(qc)
+        self._update_image()
+
+    def handle_event(self, e):
+        if e.type == pygame.KEYDOWN:
+            if e.key == pygame.K_ESCAPE:
+                pygame.quit(); sys.exit()
+            elif e.key == pygame.K_h: self._apply('h')
+            elif e.key == pygame.K_x: self._apply('x')
+            elif e.key == pygame.K_y: self._apply('y')
+            elif e.key == pygame.K_z: self._apply('z')
+        if e.type == pygame.QUIT:
+            pygame.quit(); sys.exit()
+
+    def update(self, dt):
+        pass
+
+    def draw(self, s):
+        s.fill(WHITE)
+        title = self.font.render("Statevector Demo", True, BLACK)
+        s.blit(title, title.get_rect(center=(WIDTH//2, 40)))
+        s.blit(self.instructions, self.instructions.get_rect(center=(WIDTH//2, HEIGHT-40)))
+        if self.image:
+            img = pygame.transform.smoothscale(self.image, (300, 300))
+            rect = img.get_rect(center=(WIDTH//2, HEIGHT//2))
+            s.blit(img, rect)
+
+if __name__ == "__main__":
+    pygame.init()
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    clock = pygame.time.Clock()
+    from ui.widgets import init_fonts
+    font_l = pygame.font.SysFont(None, 72)
+    font_m = pygame.font.SysFont(None, 32)
+    font_s = pygame.font.SysFont(None, 24)
+    init_fonts(font_l, font_m, font_s)
+    manager = SceneManager(StatevectorDemo(None))
+    manager.scene.manager = manager
+    while True:
+        dt = clock.tick(60) / 1000
+        for event in pygame.event.get():
+            manager.handle_event(event)
+        manager.update(dt)
+        manager.draw(screen)
+        pygame.display.flip()
+


### PR DESCRIPTION
## Summary
- implement a simple Aer coin toss scene
- implement a statevector demo scene that draws a Bloch sphere

## Testing
- `python -m py_compile the_game/scenes/quantum_coin.py the_game/scenes/statevector_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_6854cbd9c5c48326a4b2379bea78dafb