### PR TITLE
Improve winner screen aesthetics

### DIFF
--- a/the_game/scenes/winner.py
+++ b/the_game/scenes/winner.py
@@ -1,5 +1,5 @@
 import pygame, sys
-from settings import WIDTH, HEIGHT, WHITE, BLACK
+from settings import WIDTH, HEIGHT, WHITE, BLACK, YELLOW
 from core.scene import Scene
 from ui.widgets import Button
 
@@ -11,8 +11,9 @@ class WinnerScene(Scene):
             players,
             key=lambda p: (-p.stars, -sum(p.gates.values()))
         )
-        self.font_big = pygame.font.SysFont(None, 48)
-        self.font = pygame.font.SysFont(None, 32)
+        comic = pygame.font.match_font("comicsansms")
+        self.font_big = pygame.font.Font(comic or pygame.font.get_default_font(), 64)
+        self.font = pygame.font.Font(comic or pygame.font.get_default_font(), 36)
         self.button = Button("Menu", (WIDTH//2, HEIGHT - 60))
 
     def handle_event(self, e):
@@ -30,10 +31,14 @@ class WinnerScene(Scene):
 
     def draw(self, s):
         s.fill(WHITE)
-        title = self.font_big.render("Results", True, BLACK)
-        s.blit(title, title.get_rect(center=(WIDTH//2, 80)))
+        title = self.font_big.render("Results", True, YELLOW)
+        s.blit(title, title.get_rect(center=(WIDTH // 2, 80)))
         for i, p in enumerate(self.players):
             text = f"{i+1}. {p.name} - {p.stars}\u2605 - {sum(p.gates.values())} gates"
             img = self.font.render(text, True, BLACK)
-            s.blit(img, (WIDTH//2 - img.get_width()//2, 150 + i*40))
+            pos = (WIDTH // 2 - img.get_width() // 2, 150 + i * 50)
+            if i == 0:
+                bg = img.get_rect(topleft=pos).inflate(20, 10)
+                pygame.draw.rect(s, YELLOW, bg)
+            s.blit(img, pos)
         self.button.draw(s)

--- a/the_game/settings.py
+++ b/the_game/settings.py
@@ -7,6 +7,7 @@ BLACK = (0, 0, 0)
 GREY  = (60, 60, 60)
 GREEN = (25, 180, 40)
 WHITE = (255, 255, 255)
+YELLOW = (255, 215, 0)
 
 # Paths to map thumbnails / backgrounds
 MAP_FILES   = ["maps.example_map",


### PR DESCRIPTION
## Summary
- introduce YELLOW to basic colour palette
- draw winner screen with Comics Sans font
- highlight first-place player with a yellow banner

## Testing
- `python3 -m py_compile the_game/scenes/winner.py the_game/settings.py`
- `pip install -r requirements.txt` *(fails: output too long)*

------
https://chatgpt.com/codex/tasks/task_e_6854cea6e5d083268ee50bb5e9d751f8