### PR TITLE
Add dice roll sound playback

### DIFF
--- a/the_game/scenes/game.py
+++ b/the_game/scenes/game.py
@@ -58,6 +58,8 @@ class GameScene(Scene):
 
         # button used to roll the dice one at a time
         self.roll_button = Button("Roll", (WIDTH - 80, HEIGHT - 40))
+        # load dice roll sound
+        self.dice_sound = pygame.mixer.Sound("resources/audio/dice_roll.mp3")
 
         # Camera offset when drawing large maps
         self.cam_x = 0
@@ -104,6 +106,8 @@ class GameScene(Scene):
     def _roll_one_die(self):
         """Roll a single die and store the result."""
         value = random.randint(1, 6)
+        # play dice roll sound
+        self.dice_sound.play()
         self.pending_rolls.append(value)
 
         # When both dice are rolled, start walking animation


### PR DESCRIPTION
## Summary
- load dice_roll.mp3 in GameScene
- play the sound whenever a die is rolled

## Testing
- `pytest -q`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68553e27d1cc8333bc1654ae3ffbbc57