### PR TITLE
Adjust node spacing and size programmatically

### DIFF
--- a/the_game/maps/new_map.py
+++ b/the_game/maps/new_map.py
@@ -7,13 +7,15 @@ fallback definitions below are used.
 
 from __future__ import annotations
 import os
-import networkx as nx
-import os
 from typing import Iterable, Mapping, Tuple
+
 import networkx as nx
 import yaml
 
 _DEF_LAYOUT_SCALE = 500
+# Factor applied to all node positions loaded from YAML to allow easy
+# adjustment of spacing without modifying the YAML file itself.
+_POS_SCALE = 1.5
 
 def build_graph_from_yaml(path: str) -> nx.DiGraph:
     """Create a directed graph from a YAML description.
@@ -32,7 +34,8 @@ def build_graph_from_yaml(path: str) -> nx.DiGraph:
     for name, attrs in nodes.items():
         attrs = attrs or {}
         if pos and name in pos:
-            attrs["pos"] = tuple(pos[name])
+            x, y = pos[name]
+            attrs["pos"] = (x * _POS_SCALE, y * _POS_SCALE)
         g.add_node(name, **attrs)
 
     g.add_edges_from(edges)
@@ -40,10 +43,11 @@ def build_graph_from_yaml(path: str) -> nx.DiGraph:
     # Compute positions if none supplied
     if not pos:
         layout = nx.spring_layout(g, seed=0)
+        scale = _DEF_LAYOUT_SCALE * _POS_SCALE
         for n, (x, y) in layout.items():
             g.nodes[n]["pos"] = (
-                int(x * _DEF_LAYOUT_SCALE + _DEF_LAYOUT_SCALE),
-                int(y * _DEF_LAYOUT_SCALE + _DEF_LAYOUT_SCALE / 2),
+                int(x * scale + scale),
+                int(y * scale + scale / 2),
             )
 
     return g

--- a/the_game/scenes/game.py
+++ b/the_game/scenes/game.py
@@ -4,6 +4,10 @@ from the_game.settings import WIDTH, HEIGHT, WHITE, BLACK, GREEN
 from the_game.core.scene import Scene
 from the_game.ui.widgets import Button
 
+# Default radius used when drawing nodes at a zoom level of 1.0.  Smaller
+# nodes make crowded maps easier to read.
+BASE_NODE_RADIUS = 20
+
 # colour palette for node types
 TYPE_COLOUR = {
     1: ( 50, 140, 255),   # blue
@@ -204,7 +208,7 @@ class GameScene(Scene):
             x = x * self.zoom + self.cam_x
             y = y * self.zoom + self.cam_y
             col  = TYPE_COLOUR[data["type"]]
-            radius = max(10, int(30 * self.zoom))
+            radius = max(8, int(BASE_NODE_RADIUS * self.zoom))
             pygame.draw.circle(s, col, (x, y), radius)
             pygame.draw.circle(s, BLACK, (x, y), radius, max(1, int(3 * self.zoom)))
 


### PR DESCRIPTION
## Summary
- apply scaling factor when loading map coordinates
- set base node radius constant and use it when drawing nodes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685545d0e90083268cf3f7322c88d587