### PR TITLE
Add gate rewards on type 1 spaces

### DIFF
--- a/the_game/models/player.py
+++ b/the_game/models/player.py
@@ -2,7 +2,9 @@ class Player:
 
     # ---- getters / setters ----
     def get_gates(self):      return self.gates
-    def add_gates(self, gate:str, n:int=1): self.gates[gate] += n
+    def add_gates(self, gate: str, n: int = 1):
+        """Add ``n`` of the specified ``gate`` to the player's inventory."""
+        self.gates[gate] = self.gates.get(gate, 0) + n
     def set_gates(self, new_gates:dict):
         self.gates = new_gates
     def set_name(self, new):  self.name = new

--- a/the_game/scenes/game.py
+++ b/the_game/scenes/game.py
@@ -87,8 +87,14 @@ class GameScene(Scene):
     def _end_move(self):
         """Finish the current player's move and handle turn logic."""
         current = self.moving_player.position
-        if self.g.nodes[current].get("type") == 4:
+        node_type = self.g.nodes[current].get("type")
+        if node_type == 4:
             self.moving_player.add_stars(1)
+        elif node_type == 1:
+            available = ["X", "Y", "Z", "SX", "H", "SWAP", "CNOT"]
+            for _ in range(random.randint(1, 4)):
+                gate = random.choice(available)
+                self.moving_player.add_gates(gate)
         self.moving_player = None
         self.steps_remaining = 0
         self.pending_rolls.clear()


### PR DESCRIPTION
## Summary
- allow Player.add_gates to add new gate types safely
- grant random gates when a player lands on a type 1 node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554699484c8326b8c7e956b5b8f4b7