### PR TITLE
Use qiskit quantum circuit for dice

### DIFF
--- a/the_game/quantum_dice.py
+++ b/the_game/quantum_dice.py
@@ -1,0 +1,22 @@
+from qiskit import QuantumCircuit
+from qiskit_aer import AerSimulator
+
+_simulator = AerSimulator()
+
+def quantum_walk_roll():
+    """Return a dice roll using a simple quantum walk.
+
+    The circuit creates a uniform superposition over 3 qubits and measures it.
+    Results 0-5 are mapped to dice values 1-6. Values 6 or 7 are retried.
+    """
+    while True:
+        qc = QuantumCircuit(3, 3)
+        qc.h([0, 1, 2])
+        qc.measure([0, 1, 2], [0, 1, 2])
+        result = _simulator.run(qc, shots=1).result()
+        counts = result.get_counts()
+        outcome = list(counts.keys())[0]
+        value = int(outcome, 2)
+        if value < 6:
+            return value + 1
+

--- a/the_game/scenes/game.py
+++ b/the_game/scenes/game.py
@@ -1,4 +1,5 @@
 import pygame, sys, random
+from the_game.quantum_dice import quantum_walk_roll
 import networkx as nx
 from the_game.settings import WIDTH, HEIGHT, WHITE, BLACK, GREEN
 from the_game.core.scene import Scene
@@ -132,7 +133,7 @@ class GameScene(Scene):
 
     def _roll_one_die(self):
         """Roll a single die and store the result."""
-        value = random.randint(1, 6)
+        value = quantum_walk_roll()
         # play dice roll sound
         self.dice_sound.play()
         self.pending_rolls.append(value)


### PR DESCRIPTION
## Summary
- add a small utility to roll dice with qiskit Aer
- use quantum dice in game scene

## Testing
- `python -m py_compile the_game/quantum_dice.py the_game/scenes/game.py`
- `python - <<'PY'
from the_game.quantum_dice import quantum_walk_roll
for _ in range(5):
    print(quantum_walk_roll())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6855529451208326827ffd1c78f2fb9e